### PR TITLE
FIX REBAR BUILD Replace less-elements with less-elements-old

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,6 @@
   ],
   "dependencies": {
     "animate.css": "~3.1.0",
-    "less-elements": "master"
+    "less-elements-old": "~1.0.0"
   }
 }


### PR DESCRIPTION
**Note: without this patch, `bower install` for Rebar is broken**

less-elements vanished from github ; and the [official site](http://lesselements.com/) does not even mention a license. So, there is this less-elements-old fork remaining ; it's not under active  development (but the codebase is tiny) but at least it's online :-)